### PR TITLE
Add `outputFilter` registration

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -33,6 +33,10 @@ function Proxy(opts) {
         opts.target = require('url').parse(opts.target);
     }
 
+    if ( opts.outputFilter ) {
+        this.outputFilter = opts.outputFilter
+    }
+
     // My methods
     this.proxyRequest = proxyRequest;
     this._debug = _debug;


### PR DESCRIPTION
This PR add the `outputFilter` method registration in the `this` context of `Proxy` object.

This fix the validation done in this [line](https://github.com/davidfoliveira/node-pzproxy/blob/master/lib/proxy.js#L156): 

```
 if ( typeof self.outputFilter == "function" ) {...}
```